### PR TITLE
Bump version: 1.3.0 → 1.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ jobs:
         githubToken: ${{ github.token }}
 ```
 
-> NOTE: GitHub Code Scanning features are free for public repositories. For private repositories, a GitHub Advanced Security license is required.
+> NOTE: GitHub Code Scanning features are free for public repositories. For private repositories, a [GitHub Advanced Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security) license is required.
 
 ### `githubToken`
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ See the [Docker documentation](https://docs.docker.com/engine/reference/run/#net
 
 **Optional** *(requires `githubToken`)* If set to `true`, uploads SARIF scan data to GitHub so that scan results are available from [Code Scanning](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning).
 
+The `codeScanningAlerts` feature works in conjunction with the HawkScan's [`hawk.failureThreshold`](https://docs.stackhawk.com/hawkscan/configuration/#hawk) configuration option. If your scan produces alerts that meet or exceed your `hawk.failureThreshold` alert level, it will trigger a Code Scanning alert in GitHub with a link to your scan results.
+
 For example:
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ See the [Docker documentation](https://docs.docker.com/engine/reference/run/#net
 
 ### `codeScanningAlerts`
 
-**Optional** *(requires `githubToken`)* If set to `true`, uploads SARIF scan data to GitHub so that scan results are available from [Code Scanning](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning).
+**Optional** *(requires [`githubToken`](#githubtoken))* If set to `true`, uploads SARIF scan data to GitHub so that scan results are available from [Code Scanning](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning).
 
-The `codeScanningAlerts` feature works in conjunction with the HawkScan's [`hawk.failureThreshold`](https://docs.stackhawk.com/hawkscan/configuration/#hawk) configuration option. If your scan produces alerts that meet or exceed your `hawk.failureThreshold` alert level, it will trigger a Code Scanning alert in GitHub with a link to your scan results.
+The `codeScanningAlerts` feature works in conjunction with the HawkScan's [`hawk.failureThreshold`](https://docs.stackhawk.com/hawkscan/configuration/#hawk) configuration option. If your scan produces alerts that meet or exceed your `hawk.failureThreshold` alert level, it will fail the scan with exit code 42, and trigger a Code Scanning alert in GitHub with a link to your scan results.
 
 For example:
 ```yaml
@@ -113,6 +113,8 @@ jobs:
         codeScanningAlerts: true
         githubToken: ${{ github.token }}
 ```
+
+> NOTE: GitHub Code Scanning features are free for public repositories. For private repositories, a GitHub Advanced Security license is required.
 
 ### `githubToken`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v1.3.0
+    - uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
 ```
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v1.3.0
+    - uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         dryRun: true
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v1.3.0
+    - uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         environmentVariables: APP_HOST APP_ENV
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v1.3.0
+    - uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         configurationFiles: stackhawk.yml stackhawk-extra.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v1.3.0
+    - uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         codeScanningAlerts: true
@@ -137,7 +137,7 @@ jobs:
         pip3 install -r requirements.txt
         nohup python3 app.py &
     - name: Scan my app
-      uses: stackhawk/hawkscan-action@v1.3.0
+      uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
 ```
@@ -161,7 +161,7 @@ jobs:
         APP_HOST: 'http://localhost:5000'
         APP_ID: AE624DB7-11FC-4561-B8F2-2C8ECF77C2C7
         APP_ENV: Development
-      uses: stackhawk/hawkscan-action@v1.3.0
+      uses: stackhawk/hawkscan-action@v1.3.1
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         dryRun: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawkscan-action",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "StackHawk HawkScan Action",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Clarify `codeScanningAlerts` documentation:
* Add reference to associated StackHawk `hawk.failureThreshold` configuration
* Add note regarding GitHub Advanced Security license requirement for private repos
* Add link from `codeScanningAlerts` section to required `githubToken` section

![crystal](https://media.giphy.com/media/czusrRLDtmUoShJRcm/giphy.gif?cid=ecf05e47vf0769zslxo4z4g5qqi2gl2mgj8i89paftas81nq&rid=giphy.gif&ct=g)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> 3274
> 3275

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
