### PR TITLE
Prepare for v2.1.1 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.1.1
 commit = True
 tag = False
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Packaging creates a single consolidated action file in the `dist` folder. That d
 
 To release a new version of this action to the marketplace, you must do the following:
  1. Lint, package, and test the code in your feature branch
- 2. Bump the version number in `package.json` and `README.md`
+ 2. Bump the version number in `package.json` and `README.md` and `.bumpversion.cfg`. run npm install again to ensure version attaches in package-lock.json.
  3. Create a PR to `main` with your changes
  4. Once the PR is merged, tag and release it
  5. Publish the release to the GitHub Marketplace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hawkscan-action",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hawkscan-action",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",


### PR DESCRIPTION
## Description of the change

> I missed a few versions in the package-lock.json and drift from the bumpversion.cfg. Quick adjustment before deployment.
<!-- please share a quality (SFW) gif or photo -->
<!-- before-and-after UI picks are a good addition as well -->
![replace me](https://media.giphy.com/media/xT5LMUt1dWrBQtacJG/giphy.gif)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> SCAN-1256

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
