### PR TITLE
ENG-599: hawkscan-action v3.0.0 — major release for hawkscan 6.0.0 binary support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 3.0.0
 commit = True
 tag = False
 

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -11,6 +11,7 @@ on:
         type: choice
         description: The main version to update
         options:
+          - v3
           - v2
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
 ```
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         args: |
           --hawk-mem 1g
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         command: rescan
 ```
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         dryRun: true
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         configurationFiles: stackhawk.yml stackhawk-extra.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
     with:
       installCLIOnly: true
     - name: Run CLI Scan
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         codeScanningAlerts: true
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: stackhawk/hawkscan-action@v2.5.0
+    - uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         commitShaCheck: true
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: stackhawk/hawkscan-action@v2.5.0
+      - uses: stackhawk/hawkscan-action@v3.0.0
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}
           verbose: true
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: stackhawk/hawkscan-action@v2.5.0
+      - uses: stackhawk/hawkscan-action@v3.0.0
         with:
           workspace: ./app/config/
 ```
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: stackhawk/hawkscan-action@v2.5.0
+      - uses: stackhawk/hawkscan-action@v3.0.0
         with:
           version: 2.7.0
 ```
@@ -233,7 +233,7 @@ jobs:
         pip3 install -r requirements.txt
         nohup python3 app.py &
     - name: Scan my app
-      uses: stackhawk/hawkscan-action@v2.5.0
+      uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
 ```
@@ -257,7 +257,7 @@ jobs:
         APP_HOST: 'http://localhost:5000'
         APP_ID: AE624DB7-11FC-4561-B8F2-2C8ECF77C2C7
         APP_ENV: Development
-      uses: stackhawk/hawkscan-action@v2.5.0
+      uses: stackhawk/hawkscan-action@v3.0.0
       with:
         apiKey: ${{ secrets.HAWK_API_KEY }}
         dryRun: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawkscan-action",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "StackHawk HawkScan Action",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps to v3.0.0 (major) for hawkscan 6.0.0 binary distribution support
- Version-gated binary download was merged in PRs #286 and #287; this PR cuts the release
- Adds `v3` option to `update-main-version.yml` workflow

## Releasing
After merge, CI auto-creates the `v3.0.0` GitHub Release via `scripts/version-check.sh`. Then:
1. Manually publish release to GitHub Marketplace
2. Run **Update Main Version** workflow: set `v3` → `v3.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)