### PR TITLE
ci: group npm dependabot updates weekly to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates once a week
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      # Bundle minor and patch updates into one PR per week.
+      # Major updates still open individually — they need dedicated review.
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Description of the change

Investigated a reported increase in Dependabot activity. Open security alerts are at zero — last week's #294 fixed all of them. What looked like "more alerts" today were three routine version-bump PRs (#295, #296, #297) opened by the daily, ungrouped schedule.

This PR groups npm minor/patch updates into one weekly PR. Major updates (e.g. a future js-yaml 5.x bump) still open individually so they get dedicated review.

### Follow-up (not in this PR)
Repository setting `dependabot_security_updates` is currently disabled. Enabling it lets Dependabot auto-open a fix PR the moment a real security alert appears, instead of alerts accumulating until a manual sweep:
```
gh api -X PUT repos/stackhawk/hawkscan-action/automated-security-fixes
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> No linked ticket — investigation was reactive, not ticket-driven.

## Checklists

### Development

- [x] Lint rules pass locally (config-only change; no lint-relevant code touched)
- [x] The code changed/added as part of this pull request has been covered with tests (config-only change; validated `.github/dependabot.yml` parses with `yaml.safe_load`)
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer.
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

## Test plan
- [x] Confirm `.github/dependabot.yml` parses correctly (validated locally with `yaml.safe_load`)
- [ ] After merge, watch the next scheduled Dependabot run to confirm minor/patch updates are grouped into a single PR